### PR TITLE
Feat: Adds SSE Fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xintuition/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for interacting with the Intuition knowledge graph.",
   "license": "MIT",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@0xintuition/mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for interacting with the Intuition knowledge graph.",
   "license": "MIT",
   "author": "",


### PR DESCRIPTION
# Overview

- Adds the fallback to support SSE (`/sse`) alongside StreamableHttp (`/mcp`)
- Point tools that only support SSE to the `/sse` endpoint, but suggest using StreamableHttp (`/mcp`) where supported as SSE is being deprecated
- Cleans up / streamlines some of the transport logic to align with the MCP SDK newest recommendations
- Tested both transports in the MCP explorer and received successful responses for both transport types