### PR TITLE
chore: add minimumReleaseAge to defend against supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
## Summary
- Add `min-release-age=7` (7 days) to `.npmrc` for npm
- Prevents installing package versions published less than 7 days ago
- Defense-in-depth against supply chain attacks

## References
- https://socket.dev/blog/axios-npm-package-compromised